### PR TITLE
Send video buffering progress

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -191,6 +191,12 @@ export default class Video extends Component {
     }
   };
 
+  _onBufferProgress = (event) => {
+    if (this.props.onBufferProgress) {
+      this.props.onBufferProgress(event.nativeEvent);
+    }
+  };
+
   render() {
     const resizeMode = this.props.resizeMode;
     const source = resolveAssetSource(this.props.source) || {};
@@ -234,6 +240,7 @@ export default class Video extends Component {
       onVideoSeek: this._onSeek,
       onVideoEnd: this._onEnd,
       onVideoBuffer: this._onBuffer,
+      onVideoBufferProgress: this._onBufferProgress,
       onTimedMetadata: this._onTimedMetadata,
       onVideoAudioBecomingNoisy: this._onAudioBecomingNoisy,
       onVideoFullscreenPlayerWillPresent: this._onFullscreenPlayerWillPresent,
@@ -278,6 +285,7 @@ Video.propTypes = {
   onVideoLoadStart: PropTypes.func,
   onVideoLoad: PropTypes.func,
   onVideoBuffer: PropTypes.func,
+  onVideoBufferProgress: PropTypes.func,
   onVideoError: PropTypes.func,
   onVideoProgress: PropTypes.func,
   onVideoSeek: PropTypes.func,
@@ -351,6 +359,7 @@ Video.propTypes = {
   onLoadStart: PropTypes.func,
   onLoad: PropTypes.func,
   onBuffer: PropTypes.func,
+  onBufferProgress: PropTypes.func,
   onError: PropTypes.func,
   onProgress: PropTypes.func,
   onSeek: PropTypes.func,

--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -21,6 +21,7 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoLoadStart;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoLoad;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoBuffer;
+@property (nonatomic, copy) RCTBubblingEventBlock onVideoBufferProgress;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoError;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoProgress;
 @property (nonatomic, copy) RCTBubblingEventBlock onVideoSeek;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -635,7 +635,8 @@ static int const RCTVideoUnset = -1;
         return;
       }
       if (self.onVideoBufferProgress) {
-        self.onVideoBufferProgress(@{@"bufferedPercentage": @(playableDuration / totalDuration * 100.0)});
+        self.onVideoBufferProgress(@{@"bufferedPercentage": @(playableDuration / totalDuration * 100.0),
+                                     @"playableDuration": [NSNumber numberWithFloat:playableDuration]});
       }
     }
   } else if (object == _playerLayer) {

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -12,6 +12,7 @@ static NSString *const playbackBufferEmptyKeyPath = @"playbackBufferEmpty";
 static NSString *const readyForDisplayKeyPath = @"readyForDisplay";
 static NSString *const playbackRate = @"rate";
 static NSString *const timedMetadata = @"timedMetadata";
+static NSString *const loadedTimeRangesKeyPath = @"loadedTimeRanges";
 
 static int const RCTVideoUnset = -1;
 
@@ -293,6 +294,7 @@ static int const RCTVideoUnset = -1;
   [_playerItem addObserver:self forKeyPath:playbackBufferEmptyKeyPath options:0 context:nil];
   [_playerItem addObserver:self forKeyPath:playbackLikelyToKeepUpKeyPath options:0 context:nil];
   [_playerItem addObserver:self forKeyPath:timedMetadata options:NSKeyValueObservingOptionNew context:nil];
+  [_playerItem addObserver:self forKeyPath:loadedTimeRangesKeyPath options:0 context:nil];
   _playerItemObserversSet = YES;
 }
 
@@ -306,6 +308,7 @@ static int const RCTVideoUnset = -1;
     [_playerItem removeObserver:self forKeyPath:playbackBufferEmptyKeyPath];
     [_playerItem removeObserver:self forKeyPath:playbackLikelyToKeepUpKeyPath];
     [_playerItem removeObserver:self forKeyPath:timedMetadata];
+    [_playerItem removeObserver:self forKeyPath:loadedTimeRangesKeyPath];
     _playerItemObserversSet = NO;
   }
 }
@@ -625,6 +628,15 @@ static int const RCTVideoUnset = -1;
       }
       _playerBufferEmpty = NO;
       self.onVideoBuffer(@{@"isBuffering": @(NO), @"target": self.reactTag});
+    } else if ([keyPath isEqualToString:loadedTimeRangesKeyPath]) {
+      const float playableDuration = [self calculatePlayableDuration].floatValue;
+      const Float64 totalDuration = CMTimeGetSeconds(_playerItem.duration);
+      if (totalDuration <= 0.0) {
+        return;
+      }
+      if (self.onVideoBufferProgress) {
+        self.onVideoBufferProgress(@{@"bufferedPercentage": @(playableDuration / totalDuration * 100.0)});
+      }
     }
   } else if (object == _playerLayer) {
     if([keyPath isEqualToString:readyForDisplayKeyPath] && [change objectForKey:NSKeyValueChangeNewKey]) {

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -42,6 +42,7 @@ RCT_EXPORT_VIEW_PROPERTY(progressUpdateInterval, float);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoBuffer, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoBufferProgress, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoError, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoProgress, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoSeek, RCTBubblingEventBlock);


### PR DESCRIPTION
Test: in VideoSlide.js, add a console log, make sure we print something like this: (progress, video_id)

'handleVideoBufferProgress', 0.3794753348408428, 588
'handleVideoBufferProgress', 0, 583
'handleVideoBufferProgress', 0.45436586417825925, 582
'handleVideoBufferProgress', 99.99999786009393, 588
'handleVideoBufferProgress', 100.0000040725077, 583
'handleVideoBufferProgress', 99.99999600594714, 582
'handleVideoBufferProgress', 99.99999786009393, 588
'handleVideoBufferProgress', 99.99999786009393, 588
'handleVideoBufferProgress', 99.99999786009393, 588